### PR TITLE
bug fix: constant ROW_EXPO not found

### DIFF
--- a/src/fpylll/contrib/simple_bkz.py
+++ b/src/fpylll/contrib/simple_bkz.py
@@ -22,7 +22,7 @@ class BKZReduction:
         wrapper()
 
         self.A = A
-        self.m = GSO.Mat(A, flags=gso.ROW_EXPO)
+        self.m = GSO.Mat(A, flags=gso.GSO.ROW_EXPO)
         self.lll_obj = LLL.Reduction(self.m)
 
     def __call__(self, block_size):


### PR DESCRIPTION
This is just a very minor fix for an error that i get when trying to create a BKZReduction object.